### PR TITLE
Move plugin configuration to a class method

### DIFF
--- a/lib/tinymce/plugins/ice/plugin.js
+++ b/lib/tinymce/plugins/ice/plugin.js
@@ -23,6 +23,22 @@
     css: 'css/ice.css',                       // relative path
     manualInit: false,
     scriptVersion: new Date().getTime(),
+    getPlugins: function() {
+      return [
+        'IceEmdashPlugin',
+        'IceAddTitlePlugin',
+        'IceSmartQuotesPlugin',
+        {
+          name: 'IceCopyPastePlugin',
+          settings: {
+            pasteType: 'formattedClean',
+            preserve: this.preserveOnPaste,
+            beforePasteClean: this.beforePasteClean,
+            afterPasteClean: this.afterPasteClean
+          }
+        }
+      ];
+    },
     afterInit: function() {},
     afterClean: function(body) { return body; },
     beforePasteClean: function(body) { return body; },
@@ -144,20 +160,7 @@
               id: self.user.id,
               name: self.user.name
             },
-            plugins: [
-              'IceEmdashPlugin',
-              'IceAddTitlePlugin',
-              'IceSmartQuotesPlugin',
-              {
-                name: 'IceCopyPastePlugin',
-                settings: {
-                  pasteType: 'formattedClean',
-                  preserve: self.preserveOnPaste,
-                  beforePasteClean: self.beforePasteClean,
-                  afterPasteClean: self.afterPasteClean
-                }
-              }
-            ],
+            plugins: self.getPlugins(),
             changeTypes: {
               insertType: {tag: self.insertTag, alias: self.insertClass},
               deleteType: {tag: self.deleteTag, alias: self.deleteClass}


### PR DESCRIPTION
* This allows access to the class methods (beforePasteClean etc)
  which is useful if IceCopyPastePlugin is desired but other
  default plugins are not
* This allows the plugins to be overridden in the tinymce.init via 
  the ice: config