### PR TITLE
Add undo history snapshot when deleting text with Ice

### DIFF
--- a/lib/tinymce/plugins/ice/plugin.js
+++ b/lib/tinymce/plugins/ice/plugin.js
@@ -176,6 +176,10 @@
             window.console.log(txt.replace(/<br\/>/g, '\n'));
           }
 
+          changeEditor.element.addEventListener('ice:deleteContents', function () {
+            ed.undoManager.add();
+          });
+
           // since onEvent doesn't seem to exist in TinyMce4 override the events as necessary
           ed.on('mousedown', function(e) {
             return changeEditor.handleEvent(e);

--- a/src/ice.js
+++ b/src/ice.js
@@ -199,7 +199,6 @@
       }
 
     },
- 
     /*
      * Updates the list of changes to include all track tags found inside the element.
      */
@@ -528,6 +527,7 @@
 
       this.selection.addRange(range);
       this.endBatchChange(changeid);
+      this.element.dispatchEvent(new Event('ice:deleteContents'));
       return prevent;
     },
 
@@ -1606,7 +1606,6 @@
         this._preventKeyPress = false;
         return;
       }
-      
       if (!this.pluginsManager.fireKeyPress(e)) return false;
 
       var c = null;


### PR DESCRIPTION
* Ice text deletes were not individually undo-able since they were not
  triggering a snapshot as the tinyMCE "text" was unchanged
  (just wrapped in .ice-del tags)
* This patch adds an internal event on the Ice element that
  the TinyMCE plugin can catch to ensure deletion is tracked
  by the UndoManager